### PR TITLE
Made simDisplay.present more flexible

### DIFF
--- a/pkg/OPI/R/simDisplay.r
+++ b/pkg/OPI/R/simDisplay.r
@@ -81,18 +81,18 @@ simDisplay.setBackground <- function(col, gridCol) {
 # Show stim on plot for duration and wait responseWindow after.
 # No return, just die quietly if neccessary.
 ##################################################################################
-simDisplay.present <- function(x, y, color, duration, responseWindow, size = 0.43) {
+simDisplay.present <- function(stimulus) {
     if(exists("display", envir=.SimDisplayEnv)) {
         if (!is.na(.SimDisplayEnv$display)) {
             if (dev.cur() != .SimDisplayEnv$display) {  # check if window was closed
                 assign("display", NA, envir = .SimDisplayEnv)
             } else {
                 
-                simDraw.circle(x, y, size/2, col = color)
-                Sys.sleep(duration/1000.0)
+                simDraw.circle(stimulus$x, stimulus$y, stimulus$size/2, col = stimulus$color)
+                Sys.sleep(stimulus$duration/1000.0)
                 
                 simDisplay.resetDisplay()
-                Sys.sleep(abs(responseWindow - duration)/1000.0)
+                Sys.sleep(abs(stimulus$responseWindow - stimulus$duration)/1000.0)
             }
         }
     }

--- a/pkg/OPI/R/simG.r
+++ b/pkg/OPI/R/simG.r
@@ -80,7 +80,7 @@ simG.opiPresent.opiStaticStimulus <- function(stim, nextStim=NULL, fpr=0.03, fnr
 
     prSeeing <- fpr + (1-fpr-fnr)*(1-pnorm(cdTodb(stim$level, .SimGEnv$maxStim), mean=tt, sd=as.numeric(.SimGEnv$sd)))
 
-    simDisplay.present(stim$x, stim$y, stim$color, stim$duration, stim$responseWindow, stim$size)
+    simDisplay.present(stim)
 
     return ( list(
         err = NULL,

--- a/pkg/OPI/R/simH.r
+++ b/pkg/OPI/R/simH.r
@@ -139,7 +139,7 @@ simH.opiPresent.opiStaticStimulus <- function(stim, nextStim=NULL, fpr=0.03, fnr
     if (length(fpr) != length(fnr))
         warning("In opiPresent (using simHenson), recycling fpr or fnr as lengths differ")
 
-    simDisplay.present(stim$x, stim$y, stim$color, stim$duration, stim$responseWindow, stim$size)
+    simDisplay.present(stim)
 
     return(simH.present(cdTodb(stim$level, .SimHEnv$maxStim), .SimHEnv$cap, fpr, fnr, tt, .SimHEnv$A, .SimHEnv$B))
 }

--- a/pkg/OPI/R/simH_RT.r
+++ b/pkg/OPI/R/simH_RT.r
@@ -207,7 +207,7 @@ simH_RT.opiPresent.opiStaticStimulus <- function(stim, nextStim=NULL, fpr=0.03, 
     if (length(fpr) != length(fnr))
         warning("In opiPresent (using SimHensonRT), recycling fpr or fnr as lengths differ")
 
-    simDisplay.present(stim$x, stim$y, stim$color, stim$duration, stim$responseWindow, stim$size)
+    simDisplay.present(stim)
 
     return(simH_RT.present(cdTodb(stim$level, .SimHRTEnv$maxStim), fpr, fnr, tt, dist))
 }

--- a/pkg/OPI/R/simNo.r
+++ b/pkg/OPI/R/simNo.r
@@ -49,7 +49,7 @@ simNo.opiSetBackground <- function(col, gridCol) {
 #
 ################################################################################
 simNo.opiPresent <- function(stim) {
-    simDisplay.present(stim$x, stim$y, stim$color, stim$duration, stim$responseWindow, stim$size)
+    simDisplay.present(stim)
 
     return ( list(
         err = NULL,

--- a/pkg/OPI/R/simYes.r
+++ b/pkg/OPI/R/simYes.r
@@ -50,7 +50,7 @@ simYes.opiSetBackground <- function(col, gridCol) {
 #
 ################################################################################
 simYes.opiPresent <- function(stim) {
-    simDisplay.present(stim$x, stim$y, stim$color, stim$duration, stim$responseWindow, stim$size)
+    simDisplay.present(stim)
 
     return ( list(
         err = NULL,


### PR DESCRIPTION
Made the call to stimulus display more flexible. For the newer attribute of stimulus there will be no need of changing in all the files; just the file where stimulus is made and the file where it will be displayed.

Previously for every new attribute of stimulus, we had to change in all the files containing simDisplay.present call.
Now there will be no need of changing this way.